### PR TITLE
fix: scheduling errors at wrong protocol level

### DIFF
--- a/webprovider/lib/worker/rpchandler.ts
+++ b/webprovider/lib/worker/rpchandler.ts
@@ -71,7 +71,12 @@ export async function rpchandler(
 
         if (qos) {
           if (qos.immediate && !this.pool.anyIdle) {
-            throw new Error("qos: no idle workers for immediate mode");
+            // scheduling errors are WasiResponse.Error
+            traceEvent(info, wasimoff.Task_TraceEvent_EventType.ProviderError);
+            return create(wasimoff.Task_Wasip1_ResponseSchema, {
+              info: info,
+              result: { case: "error", value: String("qos: no idle workers for immediate mode") },
+            });
           }
         }
 


### PR DESCRIPTION
Previously scheduling errors were just some generic message at the Envelope level. Now scheduling errors indicate a Wasip Error and are at the same protocol level as QoS.